### PR TITLE
Improvements and fixes for v1.1

### DIFF
--- a/KPM/cli/predict_args.py
+++ b/KPM/cli/predict_args.py
@@ -62,5 +62,5 @@ class CLICommand(SharedArgs):
 
         mp = ModelPredictor(args)
 
-        diff = mp.process_xyzs()
-        mp.predict(diff)
+        fps = mp.process_xyzs()
+        mp.predict(fps)

--- a/KPM/cli/train_args.py
+++ b/KPM/cli/train_args.py
@@ -163,6 +163,11 @@ class CLICommand(SharedArgs):
                             choices=['soap', 'mbtr', 'MorganF'],
                             default='MorganF',
                             help='The type of molecular descriptor to train on.')
+        parser.add_argument('--descriptor_construction',
+                            type=str,
+                            choices=['diffs', 'concat', 'diffs+concat'],
+                            default='diffs',
+                            help='The way in which descriptors should be constructed - by subtraction, concatenation, or both.')
         parser.add_argument('--similarity_type',
                             type=str,
                             choices=['tanimoto', 'fraggle'],

--- a/KPM/cli/train_args.py
+++ b/KPM/cli/train_args.py
@@ -198,7 +198,7 @@ class CLICommand(SharedArgs):
         trainer.run(X_train, y_train)
 
         # Test model on both training and testing data.
-        tester = ModelTester(args.model_out)
+        tester = ModelTester(args.model_out, verbose=True if args.verbose == 'True' else False)
 
         Eact_pred_train, Eact_uncert_train = tester.predict(X_train, y_train, 'train')
         tester.plot_correlation(y_train, Eact_pred_train, Eact_uncert_train, 'train')

--- a/KPM/cli/train_args.py
+++ b/KPM/cli/train_args.py
@@ -181,6 +181,11 @@ class CLICommand(SharedArgs):
                             type=int,
                             default=5,
                             help='Morgan fingerprint radius.')
+        parser.add_argument('--use_natom_features',
+                            type=str,
+                            choices=['True', 'False'],
+                            default='True',
+                            help='Whether to enable natom features in difference fingerprint.')
 
 
     @staticmethod

--- a/KPM/utils/data_funcs.py
+++ b/KPM/utils/data_funcs.py
@@ -66,26 +66,26 @@ def extract_data(ea: list, dh: list, rs: list, ps: list, num_reacs: int, train_d
         for i in range(num_reacs):
             Eact[i] = ea[i]
             dH[i] = dh[i]
-            rmol.append(Chem.MolFromSmiles(rs[i], smiles_params))
-            pmol.append(Chem.MolFromSmiles(ps[i], smiles_params))
+            rmol.append(Chem.AddHs(Chem.MolFromSmiles(rs[i], smiles_params)))
+            pmol.append(Chem.AddHs(Chem.MolFromSmiles(ps[i], smiles_params)))
     elif train_direction == 'backward':
         for i in range(num_reacs):
             Eact[i] = ea[i] - dh[i]
             dH[i] = -dh[i]
-            rmol.append(Chem.MolFromSmiles(ps[i], smiles_params))
-            pmol.append(Chem.MolFromSmiles(rs[i], smiles_params))
+            rmol.append(Chem.AddHs(Chem.MolFromSmiles(ps[i], smiles_params)))
+            pmol.append(Chem.AddHs(Chem.MolFromSmiles(rs[i], smiles_params)))
     elif train_direction == 'both':
         half_reacs = int(num_reacs/2)
         for i in range(half_reacs):
             Eact[i] = ea[i]
             dH[i] = dh[i]
-            rmol.append(Chem.MolFromSmiles(rs[i], smiles_params))
-            pmol.append(Chem.MolFromSmiles(ps[i], smiles_params))
+            rmol.append(Chem.AddHs(Chem.MolFromSmiles(rs[i], smiles_params)))
+            pmol.append(Chem.AddHs(Chem.MolFromSmiles(ps[i], smiles_params)))
         for i in range(half_reacs):
             Eact[i+half_reacs] = ea[i] - dh[i]
             dH[i+half_reacs] = -dh[i]
-            rmol.append(Chem.MolFromSmiles(ps[i], smiles_params))
-            pmol.append(Chem.MolFromSmiles(rs[i], smiles_params))
+            rmol.append(Chem.AddHs(Chem.MolFromSmiles(ps[i], smiles_params)))
+            pmol.append(Chem.AddHs(Chem.MolFromSmiles(rs[i], smiles_params)))
 
     return Eact, dH, rmol, pmol
 

--- a/KPM/utils/descriptors.py
+++ b/KPM/utils/descriptors.py
@@ -1,5 +1,5 @@
 import numpy as np
-from rdkit.Chem import AllChem
+from rdkit.Chem import AllChem, rdmolops
 from rdkit import DataStructs
 from numpy.typing import ArrayLike
 
@@ -74,3 +74,74 @@ def calc_diffs_morgan(num_reacs: int, rmol: list, pmol: list, dH: ArrayLike,
         diffs[i, num_bits] = dH[i]
 
     return diffs
+
+
+def get_atypes(rmol: list):
+    '''Gets a list of all unique atom types.
+    
+    Arguments:
+        rmol: List of reactant RDKit MOL objects (equivalent to products in terms of atom types).'''
+    atypes = set()
+    for mol in rmol:
+        for atom in mol.GetAtoms():
+            atypes.add(atom.GetSymbol())
+
+    return atypes
+
+def calc_natom_features(num_reacs: int, rmol: list, pmol: list, atypes: list):
+    '''Calculate additional features relating to numbers of atoms in reactions.
+
+    Currently implements (for each atom type in `atypes`):
+    * Number of atoms.
+    * Total number of positive charges on atoms in reactants and products.
+    * Total number of negative charges on atoms in reactants and products.
+    * Total number of radical electrons on atoms in reactants and products.
+    * Total number of molecules in reactants and products.
+
+    Arguments:
+        num_reacs: Number of reactions to process difference fingerprints for.
+        rmol: List of reactant RDKit MOL objects.
+        pmol: List of product RDKit MOL objects.
+        atypes: List of atom types in training dataset.
+    '''
+    features = np.zeros((num_reacs, len(atypes)*7 + 2), dtype=int)
+    atypes_sorted = sorted(list(atypes))
+    for i in range(num_reacs):
+        atype_dict = {at: 0 for at in atypes_sorted}
+        reac_pos_chg_dict = {at: 0 for at in atypes_sorted}
+        prod_pos_chg_dict = {at: 0 for at in atypes_sorted}
+        reac_neg_chg_dict = {at: 0 for at in atypes_sorted}
+        prod_neg_chg_dict = {at: 0 for at in atypes_sorted}
+        reac_rad_dict = {at: 0 for at in atypes_sorted}
+        prod_rad_dict = {at: 0 for at in atypes_sorted}
+        for atom in rmol[i].GetAtoms():
+            sym = atom.GetSymbol()
+            atype_dict[sym] += 1
+            chg = atom.GetFormalCharge()
+            if chg > 0:
+                reac_pos_chg_dict[sym] += chg
+            elif chg < 0:
+                reac_neg_chg_dict[sym] += chg
+            reac_rad_dict[sym] += atom.GetNumRadicalElectrons()
+        for atom in pmol[i].GetAtoms():
+            sym = atom.GetSymbol()
+            chg = atom.GetFormalCharge()
+            if chg > 0:
+                prod_pos_chg_dict[sym] += chg
+            elif chg < 0:
+                prod_neg_chg_dict[sym] += chg
+            prod_rad_dict[sym] += atom.GetNumRadicalElectrons()
+        
+        atype_feats = np.array([atype_dict[at] for at in atypes_sorted])
+        chg_feats = np.concatenate([
+            [reac_pos_chg_dict[at] for at in atypes_sorted],
+            [reac_neg_chg_dict[at] for at in atypes_sorted],
+            [prod_pos_chg_dict[at] for at in atypes_sorted],
+            [prod_neg_chg_dict[at] for at in atypes_sorted]])
+        rad_feats = np.concatenate([
+            [reac_rad_dict[at] for at in atypes_sorted],
+            [prod_rad_dict[at] for at in atypes_sorted]])
+        nmol_feats = [len(rdmolops.GetMolFrags(pmol[i])), len(rdmolops.GetMolFrags(rmol[i]))]
+        features[i, :] = np.concatenate((atype_feats, chg_feats, rad_feats, nmol_feats))
+
+    return features

--- a/KPM/utils/descriptors.py
+++ b/KPM/utils/descriptors.py
@@ -3,11 +3,13 @@ from rdkit.Chem import AllChem, rdmolops
 from rdkit import DataStructs
 from numpy.typing import ArrayLike
 
-def calc_diffs(num_reacs: int, desc_type: str, rmol: list, pmol: list, dH: ArrayLike, 
-               morgan_radius: int = 5, morgan_num_bits: int = 1024):
-    '''Calculate reaction difference fingerprints.
+def calc_fps(num_reacs: int, desc_type: str, desc_construction: str,
+             rmol: list, pmol: list, dH: ArrayLike, 
+             morgan_radius: int = 5, morgan_num_bits: int = 1024):
+    '''Calculate reaction fingerprints.
     
-    Capable of calculating difference fingerprints from
+    Capable of calculating difference, concatenation or
+    difference+concatenation  fingerprints from
     SOAP, MBTR and Morgan fingerprint descriptors. Adds
     reaction enthalpy change at the end of the fingerprint
     as an extra feature.
@@ -15,6 +17,7 @@ def calc_diffs(num_reacs: int, desc_type: str, rmol: list, pmol: list, dH: Array
     Arguments:
         num_reacs: Number of reactions to process difference fingerprints for.
         desc_type: One of ['soap', 'mbtr', 'MorganF'].
+        desc_construction: One of ['diffs', 'concat', 'diffs+concat'].
         rmol: List of reactant RDKit MOL objects.
         pmol: List of product RDKit MOL objects.
         dH: Array of reaction enthalpy changes.
@@ -22,58 +25,73 @@ def calc_diffs(num_reacs: int, desc_type: str, rmol: list, pmol: list, dH: Array
         morgan_num_bits: (Optional; Default: 1024) Size (in bits) of hashed Morgan fingerprint (if using).
     '''
     if desc_type == 'soap':
-        diffs = calc_diffs_soap()
+        fps = calc_fps_soap()
     elif desc_type == 'mbtr':
-        diffs = calc_diffs_mbtr()
+        fps = calc_fps_mbtr()
     elif desc_type == 'MorganF':
-        diffs = calc_diffs_morgan(num_reacs, rmol, pmol, dH, morgan_radius, morgan_num_bits)
+        fps = calc_fps_morgan(num_reacs, desc_construction, 
+                              rmol, pmol, dH, morgan_radius, 
+                              morgan_num_bits)
     else:
         raise ValueError('Unknown desc_type!')
 
-    return diffs
+    return fps
 
 
-def calc_diffs_soap():
+def calc_fps_soap():
     raise NotImplementedError()
 
 
-def calc_diffs_mbtr():
+def calc_fps_mbtr():
     raise NotImplementedError()
-    
 
-def calc_diffs_morgan(num_reacs: int, rmol: list, pmol: list, dH: ArrayLike, 
-                      radius: int, num_bits: int):
-    '''Calculate Morgan fingerprint-based reaction difference fingerprints.
 
-    Arguments:
-        num_reacs: Number of reactions to process difference fingerprints for.
-        rmol: List of reactant RDKit MOL objects.
-        pmol: List of product RDKit MOL objects.
-        dH: Array of reaction enthalpy changes.
-        radius: Radius of Morgan Fingerprint.
-        num_bits: Size (in bits) of hashed Morgan fingerprint.
+def calc_fps_morgan(num_reacs: int, dc: str, rmol: list, pmol: list, dH: ArrayLike, 
+                    radius: int, num_bits: int):
+    '''Calculate Morgan fingerprint-based reaction fingerprints.
     '''
-    diffs = np.zeros([num_reacs, num_bits+1])
+    dc_featmap = {
+        'diffs': 1,
+        'concat': 2,
+        'diffs+concat': 3
+    }
+    fps = np.zeros([num_reacs, (num_bits*dc_featmap[dc])+1])
     for i in range(num_reacs):
 
         # Calculate Morgan Fingerprint counts for reactants and products.
         fp1 = AllChem.GetHashedMorganFingerprint(rmol[i], radius, nBits=num_bits)
         fp2 = AllChem.GetHashedMorganFingerprint(pmol[i], radius, nBits=num_bits)  
-        
+
         # Convert fingerprint count arrays to numpy arrays.
         fp_arr1 = np.zeros((0,), dtype=np.int8)
         DataStructs.ConvertToNumpyArray(fp1, fp_arr1)
         fp_arr2 = np.zeros((0,), dtype=np.int8)
         DataStructs.ConvertToNumpyArray(fp2, fp_arr2)
-        
-        # Calculate difference.
-        for j in range(num_bits):
-            diffs[i, j] = fp_arr2[j] - fp_arr1[j]     
-            
-        # Add dH to the descriptor vector.
-        diffs[i, num_bits] = dH[i]
 
-    return diffs
+        # Construct final fingerprint.
+        if dc == 'diffs':
+            # Calculate difference.
+            for j in range(num_bits):
+                fps[i, j] = fp_arr2[j] - fp_arr1[j]     
+                
+        elif dc == 'concat':
+            for j in range(num_bits):
+                fps[i, j] = fp_arr1[j]
+                fps[i, num_bits+j] = fp_arr2[j]
+
+        elif dc == 'diffs+concat':
+            for j in range(num_bits):
+                fps[i, j] = fp_arr1[j]
+                fps[i, num_bits+j] = fp_arr2[j] - fp_arr1[j]
+                fps[i, 2*num_bits+j] = fp_arr2[j]
+
+        else:
+            raise ValueError('Unknown value for descriptor_construction. How did you get here?')
+
+        # Add dH to the descriptor vector.
+        fps[i, -1] = dH[i]
+
+    return fps
 
 
 def get_atypes(rmol: list):


### PR DESCRIPTION
Adds many improvements and necessary fixes:

* `ModelPredictor` now returns its predictions when called within Python
* More scikit-learn MLPRegressor options can be passed through from the command line
* Fixed a bug allowing training data to leak into the test set
* Enforced use of hydrogen information when parsing SMILES
* Added more options for constructing fingerprints, including allowing difference vs concatenation fingerprints, and adding optional features based on the number of atoms in a reaction
* Fixed training data splitting for ensembles
* Added support for early stopping to prevent overfitting